### PR TITLE
Issue 43 - TypeError: MediaWiki\Api\ApiBase::__construct() - null added as param, string expected

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,25 +15,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: 1.39
+          - mediawiki_version: '1.39'
             php_version: 8.1
             database_type: mysql
             database_image: "mysql:8"
             coverage: false
             experimental: false
-          - mediawiki_version: 1.39
+          - mediawiki_version: '1.39'
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:10"
             coverage: false
             experimental: false
-          - mediawiki_version: 1.40
+          - mediawiki_version: '1.40'
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: true
             experimental: false
-          - mediawiki_version: 1.43
+          - mediawiki_version: '1.43'
             php_version: 8.2
             database_type: mysql
             database_image: "mariadb:11.2"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,17 +15,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: 1.35
-            php_version: 7.4
-            database_type: mysql
-            database_image: "mysql:5.7"
-            coverage: true
-            experimental: false
-          - mediawiki_version: 1.35
-            php_version: 7.4
-            database_type: sqlite
-            coverage: false
-            experimental: false
           - mediawiki_version: 1.39
             php_version: 8.1
             database_type: mysql
@@ -38,18 +27,18 @@ jobs:
             database_image: "mariadb:10"
             coverage: false
             experimental: false
+          - mediawiki_version: 1.40
+            php_version: 8.1
+            database_type: mysql
+            database_image: "mariadb:11.2"
+            coverage: true
+            experimental: false
           - mediawiki_version: 1.43
             php_version: 8.2
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: false
             experimental: false
-          # - mediawiki_version: 1.39
-          #   php_version: 8.1
-          #   database_type: postgres
-          #   database_image: "postgres:14"
-          #   coverage: false
-          #   experimental: true
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}
       PHP_VERSION: ${{ matrix.php_version }}

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ endif
 EXTENSION=IDProvider
 
 # docker images
-MW_VERSION?=1.35
-PHP_VERSION?=7.4
-DB_TYPE?=sqlite
-DB_IMAGE?=""
+MW_VERSION?=1.39
+PHP_VERSION?=8.1
+DB_TYPE?=mysql
+DB_IMAGE?="mysql:8"
 
 # extensions
 

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "IDProvider",
-	"version": "2.0.3",
+	"version": "3.0.0-alpha1",
 	"author": [
 		"Simon Heimler",
 		"Alexander Gesinn (gesinn.it GmbH & Co. KG)",
@@ -11,7 +11,7 @@
 	"license-name": "MIT",
 	"type": "other",
 	"requires": {
-		"MediaWiki": ">= 1.31"
+		"MediaWiki": ">= 1.39"
 	},
 	"AutoloadNamespaces": {
 		"MediaWiki\\Extension\\IdProvider\\": "src/"

--- a/tests/phpunit/Unit/Api/IncrementTest.php
+++ b/tests/phpunit/Unit/Api/IncrementTest.php
@@ -23,7 +23,9 @@ use PHPUnit\Framework\TestCase;
 class IncrementTest extends TestCase {
 
 	public function testGetExamples() {
-		$increment = new Increment( new ApiMain(), null );
+		$moduleName = version_compare( MW_VERSION, '1.40', '>=' ) ? 'idprovider-increment' : null;
+
+		$increment = new Increment( new ApiMain(), $moduleName );
 		$messages = $increment->getExamplesMessages();
 		$this->assertCount( 2, $messages );
 	}

--- a/tests/phpunit/Unit/Api/IncrementTest.php
+++ b/tests/phpunit/Unit/Api/IncrementTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\TestCase;
 class IncrementTest extends TestCase {
 
 	public function testGetExamples() {
+		// Handle module name based on MediaWiki version
 		$moduleName = version_compare( MW_VERSION, '1.40', '>=' ) ? 'idprovider-increment' : null;
 
 		$increment = new Increment( new ApiMain(), $moduleName );

--- a/tests/phpunit/Unit/Api/RandomTest.php
+++ b/tests/phpunit/Unit/Api/RandomTest.php
@@ -23,7 +23,10 @@ use PHPUnit\Framework\TestCase;
 class RandomTest extends TestCase {
 
 	public function testGetExamples() {
-		$random = new Random( new ApiMain(), null );
+		// Handle module name based on MediaWiki version
+        $moduleName = version_compare( MW_VERSION, '1.40', '>=' ) ? 'idprovider-random' : null;
+
+		$random = new Random( new ApiMain(), $moduleName );
 		$messages = $random->getExamplesMessages();
 		$this->assertCount( 2, $messages );
 	}


### PR DESCRIPTION
This PR is related to #43.

This PR contains:

- updated CI, dropped support for MW 1.35, added support for MW 1.40
- two tests updated, TypeError fixed
- since MW 1.40, `ApiBase::__construct()` method requires the `$moduleName` argument to be a non-null string
- Support for MW 1.43 works good as well